### PR TITLE
fix: correctly reflect work hour protection and extension status

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,12 @@
 {
   "manifest_version": 3,
-  "name": "OopsWrongTab - Save Reputation, Stay Professional",
+  "name": "OopsWrongTab - Share your screen, not your secrets.",
   "version": "1.0.0",
   "description": "Privacy-first tab redirector that saves you from embarrassing moments during screen sharing",
   "permissions": [
     "tabs",
     "activeTab",
     "storage",
-    "alarms",
-    "identity",
     "webNavigation"
   ],
   "host_permissions": [

--- a/src/main-popup/popup.html
+++ b/src/main-popup/popup.html
@@ -30,7 +30,7 @@
                 <span class="status-dot"></span>
                 <span class="status-text">Active</span>
             </div>
-            <label class="status-toggle" title="Enable/Disable Protection">
+            <label class="status-toggle" title="Enable/Disable Extension">
                 <input type="checkbox" id="enabledToggle">
                 <span class="status-toggle-slider"></span>
             </label>
@@ -40,10 +40,14 @@
             <div class="working-hours-section">
                 <div class="section-header">
                     <span class="section-title">Working Hours Protection</span>
-                    <label class="mini-toggle">
-                        <input type="checkbox" id="workingHoursToggle">
+                    <label class="mini-toggle" title="Enable/Disable Working Hours Protection">
+                        <input type="checkbox" id="workingHoursToggle" >
                         <span class="mini-slider"></span>
                     </label>
+                    <span id="workingHoursInfo" class="info-message"
+                        style="display: none; color: red; font-size: 12px; margin-left: 8px;">
+                        Enable protection first to use this option.
+                    </span>
                 </div>
 
                 <div class="working-hours-description">

--- a/src/main-popup/popup.js
+++ b/src/main-popup/popup.js
@@ -88,6 +88,12 @@ class PopupController {
       this
     );
     PopupController.#bindEvent(
+      "#workingHoursToggle",
+      "click",
+      this.preventWorkingHoursToggleWhenDisabled,
+      this
+    );
+    PopupController.#bindEvent(
       "#startTime",
       "change",
       this.handleTimeChange,
@@ -126,6 +132,23 @@ class PopupController {
     );
     PopupController.#bindEvent("#githubBtn", "click", this.openGitHub, this);
     PopupController.#bindEvent("#helpBtn", "click", this.openHelp, this);
+  }
+
+  /**
+   * Prevents enabling workingHoursToggle when enabledToggle is off.
+   * @param {Event} event
+   */
+  preventWorkingHoursToggleWhenDisabled(event) {
+    if (!this.#settings.enabled) {
+      event.preventDefault();
+      const infoMessage = document.getElementById("workingHoursInfo");
+      if (infoMessage) {
+        infoMessage.style.display = "inline";
+        setTimeout(() => {
+          infoMessage.style.display = "none";
+        }, 3000);
+      }
+    }
   }
 
   /**

--- a/src/ui/working-hours.js
+++ b/src/ui/working-hours.js
@@ -14,6 +14,7 @@ export class WorkingHoursUI {
     const workingHoursContent = document.getElementById("workingHoursContent");
 
     workingHoursToggle.checked = controller.settings.workingHours.enabled;
+    workingHoursToggle.disabled = !controller.settings.enabled;
 
     if (controller.settings.workingHours.enabled) {
       workingHoursContent.classList.add("enabled");

--- a/src/utils/ui-updater.js
+++ b/src/utils/ui-updater.js
@@ -20,7 +20,15 @@ export class UIUpdater {
         controller.settings.enabled &&
         (!controller.settings.workingHours.enabled || isWorkingHours);
 
-      if (!controller.settings.workingHours.enabled && isWorkingHours) {
+      if (!controller.settings.enabled) {
+        UIUpdater.#setStatus(
+          statusText,
+          header,
+          statusIndicator,
+          "Protection Disabled",
+          false
+        );
+      } else if (!controller.settings.workingHours.enabled && isWorkingHours) {
         UIUpdater.#setStatus(
           statusText,
           header,


### PR DESCRIPTION
This patch addresses two user-facing bugs:
- Protection still activates during work hours even if the extension is disabled.
- UI incorrectly displays that protection is ON even when it's not.

Fix ensures logic strictly respects both settings, and improves user clarity.